### PR TITLE
Add `&rest` marker to adviced `mu4e-context-switch`

### DIFF
--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -513,7 +513,7 @@ ALL-MAILS are the all the unread emails"
 
 ;; Tying all the above together
 
-(defun mu4e-alert--context-switch (orig args)
+(defun mu4e-alert--context-switch (orig &rest args)
   "Advice to update mode-line after changing the context.
 ORIG is the original function to be called with ARGS."
   (let ((context mu4e~context-current))


### PR DESCRIPTION
When switching contexts:

```
apply: Wrong number of arguments: ((t) (orig args) "Advice to update mode-line after changing the context.
ORIG is the original function to be called with ARGS." (let ((context mu4e~context-current)) (apply orig args) (if (equal context (mu4e-context-current)) nil (mu4e-alert-update-mail-count-modeline)))), 3
```

Looks like this happens on adviced function, due to incorrect definition of the argument list.
Wrong list of arguments passed to `advice-add`'s inner `apply` function.

Emacs manual recomends to use `&rest`:

- https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html

Closes #2.