### PR TITLE
Sets SKIP-DUPS to "t" to avoid duplicates mainly on Gmail

### DIFF
--- a/mu4e-alert.el
+++ b/mu4e-alert.el
@@ -295,7 +295,7 @@ MSG argument is message plist."
                       :date
                       'descending
                       mu4e-alert-max-messages-to-process
-                      nil
+                      t
                       nil))))
 
 (defvar mu4e-alert--callback-queue nil


### PR DESCRIPTION
When SKIP-DUPS argument is "nil", while using Gmail, mu4e will return duplicates, this will result in mu4e-alert reporting a bigger number of unread emails than the actual value of unread emails.